### PR TITLE
elRTE xhtmlTags cleanup

### DIFF
--- a/src/elrte/js/elRTE.filter.js
+++ b/src/elrte/js/elRTE.filter.js
@@ -843,7 +843,7 @@
 			if (!this.xhtml) return html;
 
 			return html.replace(this.tagRegExp, function(fullMatch, closingSlash, tagName, tagAttributes) {
-				if (/^(img|hr|br|embed|param|link)$/i.test(name)) {
+				if (/^(img|hr|br|embed|param|link)$/i.test(tagName)) {
 					return '<' + tagName + tagAttributes + ' />';
 				} else {
 					return fullMatch;

--- a/src/elrte/js/elRTE.filter.js
+++ b/src/elrte/js/elRTE.filter.js
@@ -840,7 +840,15 @@
 		 * return String
 		 **/
 		xhtmlTags : function(html) {
-			return this.xhtml ? html.replace(/<(img|hr|br|embed|param|link)([^>]*\/*)>/gi, "<$1$2 />") : html;
+			if (!this.xhtml) return html;
+
+			return html.replace(this.tagRegExp, function(fullMatch, closingSlash, tagName, tagAttributes) {
+				if (/^(img|hr|br|embed|param|link)$/i.test(name)) {
+					return '<' + tagName + tagAttributes + ' />';
+				} else {
+					return fullMatch;
+				}
+			});
 		}
 	}
 	


### PR DESCRIPTION
Hi,

we try to edit Freemarker templates including macros with elRTE.

Unfortunately these templates are a bit tricky for a WYSIWYG editor. In detail the xhtmlTags method breaks some tags.

ORIGINAL
    <img src="<@specialTag>some/path</@specialTag>">

ELRTE OUTPUT
    <img src="<@specialTag />some/path</@specialTag>">

EXPECTED OUTPUT
    <img src="<@specialTag>some/path</@specialTag>" />

I changed the xhtmlTags transformation method to handle this correctly and was wondering if you want to incorporated it into elRTE.

```
xhtmlTags : function(html) {
    if (!this.xhtml) return html;

    return html.replace(this.tagRegExp, function(fullMatch, closingSlash, tagName, tagAttributes) {
        if (/^(img|hr|br|embed|param|link)$/i.test(name)) {
            return '<' + tagName + tagAttributes + ' />';
        } else {
           return fullMatch;
        }
    });
}
```

Cheers,
René
