### PR TITLE
Use `jQuery.trim` instead of `String.prototype.trim`, it is not supported

### DIFF
--- a/src/elrte/js/elRTE.js
+++ b/src/elrte/js/elRTE.js
@@ -387,9 +387,9 @@ elRTE.prototype.val = function(v) {
 		}
 	} else {
 		if (this.source.is(':visible')) {
-			return this.filter.source2source(this.source.val()).trim();
+			return $.trim(this.filter.source2source(this.source.val()));
 		} else {
-			return this.filter.source($(this.doc.body).html()).trim();
+			return $.trim(this.filter.source($(this.doc.body).html()));
 		}
 	}
 }


### PR DESCRIPTION
Use `jQuery.trim` instead of `String.prototype.trim`, it is not supported in IE 8

And it seems, that this was just a typo
