### PR TITLE
fixing error when trying to focus on non-existing form field

### DIFF
--- a/src/ellib/js/eldialogform.js
+++ b/src/ellib/js/eldialogform.js
@@ -270,7 +270,7 @@ function elDialogForm(o) {
 						self.form.submit();
 					}
 				})
-				.filter(':first')[0].focus()
+				.first().focus()
 		}, 200);
 
 		this.dialog.dialog('open');


### PR DESCRIPTION
If you activate button like smilies you'll see the error.
