### PR TITLE
Fixed .elrte('val', '') and selection.insertHtml()

### DIFF
--- a/src/elrte/js/elRTE.js
+++ b/src/elrte/js/elRTE.js
@@ -445,7 +445,7 @@ $.fn.elrte = function(o, v) {
 		if (!this.length) {
 			return '';
 		} else if (this.length == 1) {
-			return v ? this[0].elrte.val(v) : this[0].elrte.val();
+			return v || v === '' ? this[0].elrte.val(v) : this[0].elrte.val();
 		} else {
 			ret = {}
 			this.each(function() {

--- a/src/elrte/js/elRTE.selection.js
+++ b/src/elrte/js/elRTE.selection.js
@@ -259,9 +259,10 @@ elRTE.prototype.selection = function(rte) {
 		if (this.rte.browser.msie) {
 			this.getRangeAt().range().pasteHTML(html);
 		} else {
-			var n = $(this.rte.dom.create('span')).html(html||'').get(0);
-			this.insertNode(n);
-			$(n).replaceWith($(n).html());
+			var nodes = $(this.rte.dom.create('span')).html(html||'').get(0).childNodes;
+			while (nodes.length) {
+			    this.insertNode(nodes[0]);
+			}
 		}
 		return this.cleanCache();
 	}


### PR DESCRIPTION
$("#editor").elrte('val', '') does not work correctly. It returned current content of the editor instead of setting it empty.
After $("#editor").elrte()[0].elrte.selection.insertHtml('html') iframe lose focus in Google Chrome and Safari.
