### PR TITLE
w3cRange.getStart/End returns null in IE7,8 on empty document

### DIFF
--- a/src/elrte/js/elRTE.w3cRange.js
+++ b/src/elrte/js/elRTE.w3cRange.js
@@ -156,7 +156,9 @@ elRTE.prototype.w3cRange = function(rte) {
 		var r = this.r.duplicate();
 		r.collapse(true);
 		var s = r.parentElement();
-		return s && s.nodeName == 'BODY' ? s.firstChild : s;
+		return s && s.nodeName == 'BODY'
+			? (s.firstChild ? s.firstChild : s.parentNode.parentNode)
+			: s;
 	}
 	
 	
@@ -168,7 +170,9 @@ elRTE.prototype.w3cRange = function(rte) {
 		var r = this.r.duplicate();
 		r.collapse(false);
 		var e = r.parentElement();
-		return e && e.nodeName == 'BODY' ? e.lastChild : e;
+		return e && e.nodeName == 'BODY'
+			? (e.lastChild ? e.lastChild : e.parentNode.parentNode)
+			: e;
 	}
 
 	


### PR DESCRIPTION
w3cRange.getStart and w3cRange.getEnd returns null in IE7 and IE8 on empty document

firstChild and lastChild in internet explorer can't access text nodes if it is just space, tab or CR.

There are few places where code don't check if returned node is not null

Maybe it's better to fix all this places instead of fixing w3cRange object, but for now proposed code just mimics chrome behaviour in this case and return `document` node
