### PR TITLE
Enable or Disable init DocStructure

### DIFF
--- a/src/elrte/js/ui/docstructure.js
+++ b/src/elrte/js/ui/docstructure.js
@@ -5,20 +5,24 @@
  * @param  String name  название кнопки 
  * 
  * @author:    Dmitry Levashov (dio) dio@std42.ru
+ * @modifier:  Ruslans Jermakovics (Vaflan) vaflancher@gmail.com
  * @copyright: Studio 42, http://www.std42.ru
  **/
 (function($) {
-elRTE.prototype.ui.prototype.buttons.docstructure = function(rte, name) {
-	this.constructor.prototype.constructor.call(this, rte, name);
-	
-	this.command = function() {
-		this.domElem.toggleClass('active');
-		$(this.rte.doc.body).toggleClass('el-rte-structure');
+	elRTE.prototype.ui.prototype.buttons.docstructure = function(rte, name) {
+		this.constructor.prototype.constructor.call(this, rte, name);
+
+		this.command = function() {
+			this.domElem.toggleClass('active');
+			$(this.rte.doc.body).toggleClass('el-rte-structure');
+		}
+
+		if(typeof(this.rte.options.docstructure) == 'undefined' || this.rte.options.docstructure) {
+			this.command();
+		}
+
+		this.update = function() {	
+			this.domElem.removeClass('disabled');
+		}
 	}
-	this.command();
-	
-	this.update = function() {	
-		this.domElem.removeClass('disabled');
-	}
-}
 })(jQuery);


### PR DESCRIPTION
It is now possible to Enable or Disable 'DocStructure' during initialising.
It is enough to add a new parameter to the options
{'docstructure': true}
